### PR TITLE
sass-rails changed Sass::Rails::SassTemplate so it no longer extends Spr...

### DIFF
--- a/lib/compass-rails/patches/sass_importer.rb
+++ b/lib/compass-rails/patches/sass_importer.rb
@@ -55,7 +55,7 @@ klass.class_eval do
   private
 
   def sass_importer_artiy
-    @sass_importer_artiy ||= self.class.parent::SassImporter.instance_method(:initialize).arity
+    @sass_importer_artiy ||= Sprockets::SassImporter.instance_method(:initialize).arity
   end
 
 


### PR DESCRIPTION
...ockets::SassTemplate so calling .parent::SassImporter fails. Switched to always using Sprockets::SassImporter

Merge to my forked master so we can use it now.
